### PR TITLE
Fix bracket restaurant number and text color

### DIFF
--- a/client/src/routes/bracket/+page.svelte
+++ b/client/src/routes/bracket/+page.svelte
@@ -280,7 +280,7 @@
 								#{index + 1}
 							</span>
 							<div>
-								<h2 class="text-xl font-semibold">{restaurant.name}</h2>
+								<h2 class="text-xl font-semibold text-black">{restaurant.name}</h2>
 							</div>
 						</div>
 						<div

--- a/server/routes/maps.js
+++ b/server/routes/maps.js
@@ -24,8 +24,16 @@ router.post("/restaurants", authMiddleware, async (req, res) => {
     });
   }
 
-  const listSizes = { short: 8, medium: 16, long: 32 };
-  const limit = listSizes[listSize] || 8;
+  // Handle both string and numeric listSize values
+  let limit;
+  if (typeof listSize === 'string' && !Number.isInteger(parseInt(listSize))) {
+    // Handle string identifiers like 'short', 'medium', 'long'
+    const listSizes = { short: 8, medium: 16, long: 32 };
+    limit = listSizes[listSize] || 8;
+  } else {
+    // Handle numeric values directly (8, 16, 32)
+    limit = parseInt(listSize) || 8;
+  }
   const radiusInMeters = radius * 1609.344;
 
   try {


### PR DESCRIPTION
This PR fixes two issues:\n\n1. Fixes the issue where selecting different numbers of restaurants (8, 16, 32) in the bracket was always showing 8 restaurants\n2. Changes restaurant name text color to black in the final rankings for better visibility